### PR TITLE
feat: configure ruff linting (T003)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,16 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
-line-length = 88
+line-length = 100
 target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes (unused imports F401, undefined names F821, etc.)
+    "I",   # isort (import sorting)
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Configures ruff linting per T003 requirements.

- Updates line length to 100 characters
- Adds basic lint rules: E, W, F, I (pycodestyle, pyflakes, isort)
- Target Python version 3.11+

Closes #3

Generated with [Claude Code](https://claude.ai/code)