### PR TITLE
feat: T004 Install Playwright browser binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: install install-browsers install-browsers-deps setup verify lint test clean
+
+# Install Python dependencies using UV
+install:
+	uv sync
+
+# Install dev dependencies (pytest, ruff)
+install-dev:
+	uv sync --extra dev
+
+# Install Playwright browser binaries (Chromium, Firefox, WebKit)
+install-browsers:
+	uv run playwright install
+
+# Install Playwright browsers with system dependencies (recommended for Linux CI)
+install-browsers-deps:
+	uv run playwright install --with-deps
+
+# Full project setup: installs Python deps and browser binaries
+# On Linux, automatically installs system dependencies
+setup: install
+	@if [ "$$(uname -s)" = "Linux" ]; then \
+		echo "Linux detected - installing browsers with system dependencies..."; \
+		uv run playwright install --with-deps; \
+	else \
+		echo "Installing browser binaries (Chromium, Firefox, WebKit)..."; \
+		uv run playwright install; \
+	fi
+	@echo "Setup complete."
+
+# Verify Playwright installation
+verify:
+	uv run playwright --version
+	@echo "Playwright installation verified."
+
+# Run linting
+lint:
+	uv run ruff check .
+
+# Run tests
+test:
+	uv run pytest
+
+# Remove build artifacts and virtual environment
+clean:
+	rm -rf .venv __pycache__ .ruff_cache
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.pyc" -delete 2>/dev/null || true

--- a/scripts/install_browsers.sh
+++ b/scripts/install_browsers.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install Playwright browser binaries with cross-platform support
+#
+# Usage:
+#   ./scripts/install_browsers.sh           # Auto-detect platform
+#   ./scripts/install_browsers.sh --with-deps  # Force install system deps (Linux)
+#
+# Browsers installed: Chromium, Firefox, WebKit
+
+set -euo pipefail
+
+WITH_DEPS=false
+
+# Parse arguments
+for arg in "$@"; do
+    case "$arg" in
+        --with-deps)
+            WITH_DEPS=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--with-deps]"
+            echo ""
+            echo "Options:"
+            echo "  --with-deps    Install system dependencies (Linux only)"
+            echo "  --help         Show this help message"
+            exit 0
+            ;;
+    esac
+done
+
+echo "Installing Playwright browser binaries (Chromium, Firefox, WebKit)..."
+
+OS="$(uname -s 2>/dev/null || echo 'Unknown')"
+
+if [[ "$WITH_DEPS" == "true" ]] || [[ "$OS" == "Linux" ]]; then
+    echo "Installing browsers with system dependencies..."
+    playwright install --with-deps
+else
+    playwright install
+fi
+
+echo ""
+echo "Verifying installation..."
+playwright --version
+
+echo ""
+echo "Browser installation complete."
+echo "Cache directory: $HOME/.cache/ms-playwright (Linux/macOS) or %USERPROFILE%\\AppData\\Local\\ms-playwright (Windows)"


### PR DESCRIPTION
Add Makefile and browser installation script for T004.

Implements cross-platform Playwright browser installation with Linux system dependency support.

Closes #4

Generated with [Claude Code](https://claude.ai/code)